### PR TITLE
perf: optimize timeline motion rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ pnpm check
 pnpm build
 ```
 
+Profile the complete production timeline scroll with:
+
+```bash
+pnpm benchmark:timeline
+```
+
+See [Timeline performance](docs/timeline-performance.md) for the harness, current baseline, and optimization notes.
+
 The Husky pre-commit hook runs formatting and lint checks. If it fails, run `pnpm format`, review the resulting changes, and commit again.
 
 ## Contributing

--- a/docs/timeline-performance.md
+++ b/docs/timeline-performance.md
@@ -1,0 +1,55 @@
+# Timeline performance
+
+The timeline benchmark measures the complete 2011–2026 scroll in a production build. It drives the page from the beginning to the end of the sticky timeline over six seconds, while Chrome records animation frames and main-thread rendering work.
+
+## Results
+
+These are the median results from seven trials at 1440×900 and device scale factor 1 in Chrome 151 on macOS. Both versions used the same benchmark script and production server configuration.
+
+| Metric                         |   Before |    After | Result                     |
+| ------------------------------ | -------: | -------: | -------------------------- |
+| Frame rate                     |  120 FPS |  120 FPS | Maintained                 |
+| Average frame time             |  8.33 ms |  8.33 ms | Maintained                 |
+| p95 frame time                 |  9.10 ms |  9.10 ms | Maintained                 |
+| Frames over 16.7 ms            |        0 |        0 | No regression              |
+| Long tasks                     |        0 |        0 | No regression              |
+| Style recalculations           |    1,037 |      872 | 15.9% fewer                |
+| Style recalculation time       | 70.29 ms | 66.17 ms | 5.9% less                  |
+| Initial route JavaScript, gzip | 65.81 kB | 46.16 kB | 29.9% smaller              |
+| React Doctor warnings          |        8 |        4 | 4 motion warnings resolved |
+
+Process-wide task duration varied with local machine load and is intentionally excluded from the improvement claims. The frame, long-task, style, and bundle measurements above were stable enough to use as acceptance criteria.
+
+## Changes
+
+- Motion features are loaded on demand through `LazyMotion`; the full feature bundle is deferred into its own chunk.
+- The moving atmospheric layer became static, removing a second scroll-linked transform.
+- Card reveals no longer animate CSS blur, which avoids an expensive raster effect while preserving their position, rotation, opacity, and scale motion.
+- Timeline cards no longer apply backdrop blur or unnecessary 3D transform preservation.
+- Timeline images use lazy loading and asynchronous decoding; expanded artifact images remain eager.
+- The scroll spring remains in place. Directly mapping scroll progress to the track was profiled and produced more main-thread work, so it was rejected.
+
+## Reproduce the benchmark
+
+Build and serve the production application:
+
+```bash
+pnpm build
+PORT=4173 HOST=127.0.0.1 node .output/server/index.mjs
+```
+
+In another terminal, run:
+
+```bash
+pnpm benchmark:timeline
+```
+
+The harness defaults to five trials. Its environment variables can change the target URL, trial count, duration, or Chrome binary:
+
+```bash
+TIMELINE_BENCHMARK_TRIALS=7 \
+TIMELINE_BENCHMARK_URL=http://127.0.0.1:4173 \
+pnpm benchmark:timeline
+```
+
+Use `node scripts/benchmark-timeline.mjs --json` when machine-readable output is needed.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "vite dev --port 3000",
+    "benchmark:timeline": "node scripts/benchmark-timeline.mjs",
     "generate-routes": "tsr generate",
     "build": "vite build",
     "preview": "vite preview",

--- a/scripts/benchmark-timeline.mjs
+++ b/scripts/benchmark-timeline.mjs
@@ -1,0 +1,396 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const url = process.env.TIMELINE_BENCHMARK_URL ?? 'http://127.0.0.1:4173'
+const chromium =
+  process.env.CHROMIUM_PATH ??
+  (process.platform === 'darwin'
+    ? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+    : 'chromium')
+const trials = Number(process.env.TIMELINE_BENCHMARK_TRIALS ?? 5)
+const durationMs = Number(process.env.TIMELINE_BENCHMARK_DURATION_MS ?? 6000)
+const profile = process.argv.includes('--json') ? false : true
+
+async function main() {
+  const userDataDir = await mkdtemp(join(tmpdir(), 'timeline-benchmark-'))
+  const browser = spawn(
+    chromium,
+    [
+      '--headless=new',
+      '--remote-debugging-port=0',
+      `--user-data-dir=${userDataDir}`,
+      '--window-size=1440,900',
+      '--force-device-scale-factor=1',
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      '--disable-features=Translate,BackForwardCache',
+      '--no-first-run',
+      '--no-default-browser-check',
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  )
+  const browserExit = new Promise((resolve) => browser.once('exit', resolve))
+
+  try {
+    const websocketUrl = await waitForWebSocket(browser)
+    const cdp = new CdpConnection(websocketUrl)
+    await cdp.ready
+
+    const results = []
+    for (let index = 0; index < trials; index += 1) {
+      results.push(await runTrial(cdp, index + 1))
+    }
+
+    const summary = summarize(results)
+    const report = {
+      benchmark: 'timeline-scroll',
+      url,
+      viewport: { width: 1440, height: 900, deviceScaleFactor: 1 },
+      durationMs,
+      trials,
+      summary,
+      results,
+    }
+
+    if (profile) printReport(report)
+    else process.stdout.write(`${JSON.stringify(report)}\n`)
+
+    await cdp.close()
+  } finally {
+    if (browser.exitCode === null) browser.kill('SIGTERM')
+    await browserExit
+    await rm(userDataDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    })
+  }
+}
+
+async function runTrial(cdp, trial) {
+  const { targetId } = await cdp.send('Target.createTarget', {
+    url: 'about:blank',
+  })
+  const { sessionId } = await cdp.send('Target.attachToTarget', {
+    targetId,
+    flatten: true,
+  })
+
+  try {
+    await cdp.send('Page.enable', {}, sessionId)
+    await cdp.send('Runtime.enable', {}, sessionId)
+    await cdp.send('Performance.enable', {}, sessionId)
+    await cdp.send('Page.bringToFront', {}, sessionId)
+    await cdp.send(
+      'Emulation.setDeviceMetricsOverride',
+      {
+        width: 1440,
+        height: 900,
+        deviceScaleFactor: 1,
+        mobile: false,
+      },
+      sessionId,
+    )
+    await cdp.send('Page.navigate', { url }, sessionId)
+    await waitForPage(cdp, sessionId)
+
+    const before = toMetricMap(
+      (await cdp.send('Performance.getMetrics', {}, sessionId)).metrics,
+    )
+    const result = await evaluate(
+      cdp,
+      sessionId,
+      `(${scrollBenchmark.toString()})(${durationMs})`,
+      true,
+    )
+    const after = toMetricMap(
+      (await cdp.send('Performance.getMetrics', {}, sessionId)).metrics,
+    )
+
+    return {
+      trial,
+      ...result,
+      mainThread: {
+        taskMs: delta(after, before, 'TaskDuration') * 1000,
+        scriptMs: delta(after, before, 'ScriptDuration') * 1000,
+        layoutMs: delta(after, before, 'LayoutDuration') * 1000,
+        styleMs: delta(after, before, 'RecalcStyleDuration') * 1000,
+        layouts: delta(after, before, 'LayoutCount'),
+        styleRecalculations: delta(after, before, 'RecalcStyleCount'),
+        heapBeforeMb: (before.get('JSHeapUsedSize') ?? 0) / (1024 * 1024),
+        heapAfterMb: (after.get('JSHeapUsedSize') ?? 0) / (1024 * 1024),
+        heapDeltaMb: delta(after, before, 'JSHeapUsedSize') / (1024 * 1024),
+      },
+    }
+  } finally {
+    await cdp.send('Target.closeTarget', { targetId })
+  }
+}
+
+async function waitForPage(cdp, sessionId) {
+  const deadline = Date.now() + 20_000
+  while (Date.now() < deadline) {
+    const ready = await evaluate(
+      cdp,
+      sessionId,
+      `document.readyState === 'complete' && document.querySelectorAll('.constellation-card').length > 0`,
+    )
+    if (ready) {
+      await evaluate(
+        cdp,
+        sessionId,
+        `Promise.all([document.fonts.ready, ...Array.from(document.images, image => { image.loading = 'eager'; return image.decode().catch(() => undefined) })]).then(() => new Promise(resolve => setTimeout(() => resolve(true), 500)))`,
+        true,
+      )
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Timeline did not become ready at ${url}`)
+}
+
+function scrollBenchmark(duration) {
+  return new Promise((resolve) => {
+    const section = document.querySelector('.constellation-scroll')
+    const timeline = document.querySelector('.constellation-timeline')
+    const track = document.querySelector('.constellation-track')
+    if (!section || !timeline || !track) {
+      throw new Error('Timeline benchmark selectors are missing')
+    }
+
+    const sectionTop = section.getBoundingClientRect().top + window.scrollY
+    const verticalTravel = section.offsetHeight - window.innerHeight
+    window.scrollTo(0, sectionTop)
+
+    const longTasks = []
+    const longFrames = []
+    const observers = []
+    for (const [type, output] of [
+      ['longtask', longTasks],
+      ['long-animation-frame', longFrames],
+    ]) {
+      try {
+        const observer = new PerformanceObserver((list) => {
+          output.push(...list.getEntries().map((entry) => entry.duration))
+        })
+        observer.observe({ type, buffered: true })
+        observers.push(observer)
+      } catch {
+        // The metrics stay optional on browsers without this entry type.
+      }
+    }
+
+    const deltas = []
+    let startedAt
+    let previousAt
+
+    requestAnimationFrame(function step(now) {
+      startedAt ??= now
+      previousAt ??= now
+      deltas.push(now - previousAt)
+      previousAt = now
+
+      const progress = Math.min((now - startedAt) / duration, 1)
+      window.scrollTo(0, sectionTop + verticalTravel * progress)
+
+      if (progress < 1) {
+        requestAnimationFrame(step)
+        return
+      }
+
+      requestAnimationFrame(() => {
+        observers.forEach((observer) => observer.disconnect())
+        const sorted = deltas.slice(1).sort((a, b) => a - b)
+        const elapsedMs = now - startedAt
+        resolve({
+          elapsedMs,
+          frameCount: sorted.length,
+          fps: sorted.length / (elapsedMs / 1000),
+          averageFrameMs:
+            sorted.reduce((total, value) => total + value, 0) / sorted.length,
+          p95FrameMs: percentile(sorted, 0.95),
+          p99FrameMs: percentile(sorted, 0.99),
+          framesOverBudget: sorted.filter((value) => value > 16.7).length,
+          framesOver50Ms: sorted.filter((value) => value > 50).length,
+          longestFrameMs: sorted.at(-1) ?? 0,
+          longTaskCount: longTasks.length,
+          longTaskMs: longTasks.reduce((total, value) => total + value, 0),
+          longAnimationFrameCount: longFrames.length,
+          longAnimationFrameMs: longFrames.reduce(
+            (total, value) => total + value,
+            0,
+          ),
+          horizontalTravelPx: track.scrollWidth - timeline.clientWidth,
+          verticalTravelPx: verticalTravel,
+        })
+      })
+    })
+
+    function percentile(values, quantile) {
+      if (values.length === 0) return 0
+      return values[
+        Math.min(values.length - 1, Math.floor(values.length * quantile))
+      ]
+    }
+  })
+}
+
+function summarize(results) {
+  const paths = [
+    'fps',
+    'averageFrameMs',
+    'p95FrameMs',
+    'p99FrameMs',
+    'framesOverBudget',
+    'framesOver50Ms',
+    'longTaskCount',
+    'longTaskMs',
+    'longAnimationFrameCount',
+    'longAnimationFrameMs',
+    'mainThread.taskMs',
+    'mainThread.scriptMs',
+    'mainThread.layoutMs',
+    'mainThread.styleMs',
+    'mainThread.layouts',
+    'mainThread.styleRecalculations',
+    'mainThread.heapBeforeMb',
+    'mainThread.heapAfterMb',
+    'mainThread.heapDeltaMb',
+  ]
+
+  return Object.fromEntries(
+    paths.map((path) => {
+      const values = results
+        .map((result) => readPath(result, path))
+        .sort((a, b) => a - b)
+      return [path, median(values)]
+    }),
+  )
+}
+
+function printReport(report) {
+  const rows = Object.entries(report.summary).map(([metric, value]) => ({
+    metric,
+    median: Number(value.toFixed(2)),
+  }))
+  console.log(`Timeline scroll benchmark: ${report.url}`)
+  console.log(
+    `${report.trials} trials · ${report.durationMs} ms · ${report.viewport.width}×${report.viewport.height}`,
+  )
+  console.table(rows)
+}
+
+function toMetricMap(metrics) {
+  return new Map(metrics.map(({ name, value }) => [name, value]))
+}
+
+function delta(after, before, name) {
+  return (after.get(name) ?? 0) - (before.get(name) ?? 0)
+}
+
+function readPath(value, path) {
+  return path.split('.').reduce((current, key) => current[key], value)
+}
+
+function median(values) {
+  const middle = Math.floor(values.length / 2)
+  return values.length % 2 === 0
+    ? (values[middle - 1] + values[middle]) / 2
+    : values[middle]
+}
+
+function waitForWebSocket(child) {
+  return new Promise((resolve, reject) => {
+    let output = ''
+    const timeout = setTimeout(
+      () => reject(new Error(`Chromium did not expose CDP. ${output}`)),
+      10_000,
+    )
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      output += chunk
+      const match = output.match(/DevTools listening on (ws:\/\/[^\s]+)/)
+      if (!match) return
+      clearTimeout(timeout)
+      resolve(match[1])
+    })
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      reject(
+        new Error(`Chromium exited before CDP was ready (${code}). ${output}`),
+      )
+    })
+  })
+}
+
+async function evaluate(cdp, sessionId, expression, awaitPromise = false) {
+  const response = await cdp.send(
+    'Runtime.evaluate',
+    {
+      expression,
+      awaitPromise,
+      returnByValue: true,
+    },
+    sessionId,
+  )
+  if (response.exceptionDetails) {
+    throw new Error(response.exceptionDetails.text)
+  }
+  return response.result.value
+}
+
+class CdpConnection {
+  nextId = 1
+  pending = new Map()
+
+  constructor(url) {
+    this.socket = new WebSocket(url)
+    this.ready = new Promise((resolve, reject) => {
+      this.socket.addEventListener('open', resolve, { once: true })
+      this.socket.addEventListener('error', reject, { once: true })
+    })
+    this.socket.addEventListener('message', ({ data }) => {
+      const message = JSON.parse(data)
+      if (!message.id) return
+      const pending = this.pending.get(message.id)
+      if (!pending) return
+      this.pending.delete(message.id)
+      if (message.error) pending.reject(new Error(message.error.message))
+      else pending.resolve(message.result ?? {})
+    })
+  }
+
+  async send(method, params = {}, sessionId) {
+    await this.ready
+    const id = this.nextId++
+    const message = { id, method, params }
+    if (sessionId) message.sessionId = sessionId
+    this.socket.send(JSON.stringify(message))
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+    })
+  }
+
+  close() {
+    if (this.socket.readyState === WebSocket.CLOSED) return Promise.resolve()
+    return new Promise((resolve) => {
+      const timeout = setTimeout(resolve, 1000)
+      this.socket.addEventListener(
+        'close',
+        () => {
+          clearTimeout(timeout)
+          resolve()
+        },
+        { once: true },
+      )
+      this.socket.close()
+    })
+  }
+}
+
+await main()
+await new Promise((resolve) => process.stdout.write('', resolve))
+process.exit(0)

--- a/src/components/ArtifactSearch.tsx
+++ b/src/components/ArtifactSearch.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'motion/react'
+import { m } from 'motion/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ChangeEvent, KeyboardEvent, MouseEvent } from 'react'
 import type { Artifact } from '#/data/artifacts'
@@ -15,6 +15,8 @@ const resultDate = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   timeZone: 'UTC',
 })
+
+const stopPropagation = (event: MouseEvent) => event.stopPropagation()
 
 export function ArtifactSearch({
   artifacts,
@@ -69,10 +71,8 @@ export function ArtifactSearch({
     }
   }
 
-  const stopPropagation = (event: MouseEvent) => event.stopPropagation()
-
   return (
-    <motion.div
+    <m.div
       className="search-backdrop"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
@@ -80,7 +80,7 @@ export function ArtifactSearch({
       onMouseDown={onClose}
       onKeyDown={handleKeyDown}
     >
-      <motion.section
+      <m.section
         className="search-palette"
         initial={{ opacity: 0, y: -18, scale: 0.98 }}
         animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -176,7 +176,7 @@ export function ArtifactSearch({
             <kbd>↵</kbd> Open
           </span>
         </div>
-      </motion.section>
-    </motion.div>
+      </m.section>
+    </m.div>
   )
 }

--- a/src/components/ArtifactVisual.tsx
+++ b/src/components/ArtifactVisual.tsx
@@ -16,6 +16,8 @@ export function ArtifactVisual({
         <img
           src={artifact.imageUrl}
           alt={artifact.imageAlt ?? `${artifact.name} interface`}
+          loading={expanded ? 'eager' : 'lazy'}
+          decoding="async"
         />
       </div>
     )

--- a/src/components/ConstellationTimeline.tsx
+++ b/src/components/ConstellationTimeline.tsx
@@ -1,5 +1,5 @@
 import {
-  motion,
+  m,
   useReducedMotion,
   useScroll,
   useSpring,
@@ -53,7 +53,6 @@ export function ConstellationTimeline({
     mass: 0.5,
   })
   const trackX = useTransform(progress, [0, 1], [0, -scrollDistance])
-  const atmosphereX = useTransform(progress, [0, 1], ['0%', '-18%'])
 
   useLayoutEffect(() => {
     const viewport = viewportRef.current
@@ -138,12 +137,8 @@ export function ConstellationTimeline({
         aria-label="AI interface chronology"
         tabIndex={0}
       >
-        <motion.div
-          className="constellation-atmosphere"
-          style={reduceMotion ? undefined : { x: atmosphereX }}
-          aria-hidden="true"
-        />
-        <motion.div
+        <div className="constellation-atmosphere" aria-hidden="true" />
+        <m.div
           ref={trackRef}
           className="constellation-track"
           style={
@@ -153,7 +148,7 @@ export function ConstellationTimeline({
             } as CSSProperties
           }
         >
-          <motion.div
+          <m.div
             className="constellation-axis"
             initial={reduceMotion ? false : { scaleX: 0 }}
             whileInView={{ scaleX: 1 }}
@@ -161,12 +156,12 @@ export function ConstellationTimeline({
             transition={{ duration: 1.15, ease: [0.16, 1, 0.3, 1] }}
             aria-hidden="true"
           >
-            <motion.span
+            <m.span
               className="constellation-progress"
               style={{ scaleX: progress }}
             />
             <span className="constellation-pulse" />
-          </motion.div>
+          </m.div>
 
           {orderedArtifacts.map((artifact, index) => {
             const side = index % 2 === 0 ? 'above' : 'below'
@@ -181,7 +176,7 @@ export function ConstellationTimeline({
                 style={{ '--accent': artifact.accent } as CSSProperties}
               >
                 {startsYear && (
-                  <motion.span
+                  <m.span
                     className="constellation-year"
                     initial={
                       reduceMotion
@@ -194,11 +189,11 @@ export function ConstellationTimeline({
                     aria-hidden="true"
                   >
                     {artifact.year}
-                  </motion.span>
+                  </m.span>
                 )}
                 <span className="constellation-stem" aria-hidden="true" />
                 <span className="constellation-dot" aria-hidden="true" />
-                <motion.button
+                <m.button
                   ref={(node) => {
                     nodeRefs.current[index] = node
                   }}
@@ -213,7 +208,6 @@ export function ConstellationTimeline({
                           opacity: 0,
                           y: side === 'above' ? 74 : -74,
                           rotateZ: side === 'above' ? -4 : 4,
-                          filter: 'blur(14px)',
                           scale: 0.58,
                         }
                   }
@@ -221,7 +215,6 @@ export function ConstellationTimeline({
                     opacity: 1,
                     y: 0,
                     rotateZ: side === 'above' ? -1.2 : 1.2,
-                    filter: 'blur(0px)',
                     scale: 1,
                   }}
                   viewport={{ root: viewportRef, once: true, amount: 0.25 }}
@@ -248,11 +241,11 @@ export function ConstellationTimeline({
                     <strong>{artifact.name}</strong>
                     <small>{artifact.edition}</small>
                   </span>
-                </motion.button>
+                </m.button>
               </div>
             )
           })}
-        </motion.div>
+        </m.div>
       </div>
     </div>
   )

--- a/src/components/Museum.tsx
+++ b/src/components/Museum.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from 'motion/react'
+import { AnimatePresence, LazyMotion, m } from 'motion/react'
 import { useEffect, useState } from 'react'
 import { ArtifactSearch } from './ArtifactSearch'
 import { ArtifactVisual } from './ArtifactVisual'
@@ -18,6 +18,9 @@ const formatMonth = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   timeZone: 'UTC',
 })
+
+const loadMotionFeatures = () =>
+  import('../motion-features').then((module) => module.default)
 
 export function Museum() {
   const [activeArtifact, setActiveArtifact] = useState<Artifact | null>(null)
@@ -60,70 +63,72 @@ export function Museum() {
   }, [activeArtifact, searchOpen])
 
   return (
-    <main className="museum-shell museum-shell--constellation">
-      <section className="hero" id="top">
-        <button
-          className="search-trigger"
-          type="button"
-          onMouseDown={(event) => {
-            event.preventDefault()
-            setSearchOpen(true)
-          }}
-          onClick={() => setSearchOpen(true)}
-          aria-label="Search interfaces"
-        >
-          <span>Search interfaces</span>
-          <kbd>⌘K</kbd>
-        </button>
-        <p className="eyebrow">A living collection of machine interfaces</p>
-        <h1>
-          <span>The AI</span>
-          <span>Interface Museum</span>
-        </h1>
-        <div className="hero-footer">
-          <p className="hero-thesis">
-            A visual history of how humans learned to talk to, look through,
-            create with, and delegate work to artificial intelligence.
-          </p>
-          <a href="#collection" className="explore-link">
-            Explore the collection <span>↓</span>
-          </a>
-        </div>
-      </section>
-
-      <section className="collection" id="collection">
-        <ConstellationTimeline
-          artifacts={artifacts}
-          onSelect={setActiveArtifact}
-        />
-      </section>
-
-      <footer className="museum-footer">
-        <p>
-          Built by Kyle Jeong
-          <br />© 2026
-        </p>
-      </footer>
-
-      <AnimatePresence>
-        {activeArtifact && (
-          <ArtifactDetail
-            artifact={activeArtifact}
-            onClose={() => setActiveArtifact(null)}
-          />
-        )}
-        {searchOpen && (
-          <ArtifactSearch
-            artifacts={artifacts}
-            onClose={() => setSearchOpen(false)}
-            onSelect={(artifact) => {
-              setActiveArtifact(artifact)
-              setSearchOpen(false)
+    <LazyMotion features={loadMotionFeatures} strict>
+      <main className="museum-shell museum-shell--constellation">
+        <section className="hero" id="top">
+          <button
+            className="search-trigger"
+            type="button"
+            onMouseDown={(event) => {
+              event.preventDefault()
+              setSearchOpen(true)
             }}
+            onClick={() => setSearchOpen(true)}
+            aria-label="Search interfaces"
+          >
+            <span>Search interfaces</span>
+            <kbd>⌘K</kbd>
+          </button>
+          <p className="eyebrow">A living collection of machine interfaces</p>
+          <h1>
+            <span>The AI</span>
+            <span>Interface Museum</span>
+          </h1>
+          <div className="hero-footer">
+            <p className="hero-thesis">
+              A visual history of how humans learned to talk to, look through,
+              create with, and delegate work to artificial intelligence.
+            </p>
+            <a href="#collection" className="explore-link">
+              Explore the collection <span>↓</span>
+            </a>
+          </div>
+        </section>
+
+        <section className="collection" id="collection">
+          <ConstellationTimeline
+            artifacts={artifacts}
+            onSelect={setActiveArtifact}
           />
-        )}
-      </AnimatePresence>
-    </main>
+        </section>
+
+        <footer className="museum-footer">
+          <p>
+            Built by Kyle Jeong
+            <br />© 2026
+          </p>
+        </footer>
+
+        <AnimatePresence>
+          {activeArtifact && (
+            <ArtifactDetail
+              artifact={activeArtifact}
+              onClose={() => setActiveArtifact(null)}
+            />
+          )}
+          {searchOpen && (
+            <ArtifactSearch
+              artifacts={artifacts}
+              onClose={() => setSearchOpen(false)}
+              onSelect={(artifact) => {
+                setActiveArtifact(artifact)
+                setSearchOpen(false)
+              }}
+            />
+          )}
+        </AnimatePresence>
+      </main>
+    </LazyMotion>
   )
 }
 
@@ -135,14 +140,14 @@ function ArtifactDetail({
   onClose: () => void
 }) {
   return (
-    <motion.div
+    <m.div
       className="detail-backdrop"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       onMouseDown={onClose}
     >
-      <motion.article
+      <m.article
         className="artifact-detail"
         layoutId={`card-${artifact.id}`}
         onMouseDown={(event) => event.stopPropagation()}
@@ -213,8 +218,8 @@ function ArtifactDetail({
             ))}
           </div>
         </div>
-      </motion.article>
-    </motion.div>
+      </m.article>
+    </m.div>
   )
 }
 

--- a/src/motion-features.ts
+++ b/src/motion-features.ts
@@ -1,0 +1,3 @@
+import { domMax } from 'motion/react'
+
+export default domMax

--- a/src/styles.css
+++ b/src/styles.css
@@ -357,12 +357,10 @@ button {
   box-shadow:
     0 28px 70px rgba(38, 35, 29, 0.16),
     0 0 28px rgba(184, 50, 32, 0.04);
-  backdrop-filter: blur(18px);
   text-align: left;
   cursor: pointer;
   appearance: none;
   transform: translateX(-50%);
-  transform-style: preserve-3d;
 }
 .constellation-slot[data-side='above'] .constellation-card {
   bottom: calc(50% + var(--stem));


### PR DESCRIPTION
## Summary

- defer Motion's full feature bundle with `LazyMotion`
- remove the redundant atmospheric transform, card blur animation, backdrop blur, and unnecessary 3D preservation
- lazy-load timeline images while keeping expanded artifact imagery eager
- add a reproducible Chrome CDP benchmark for the complete 2011–2026 timeline scroll

## Benchmark

Seven-trial medians from production builds at 1440×900 in Chrome 151:

| Metric | Before | After | Result |
| --- | ---: | ---: | --- |
| Frame rate | 120 FPS | 120 FPS | Maintained |
| p95 frame time | 9.10 ms | 9.10 ms | Maintained |
| Frames over 16.7 ms | 0 | 0 | No regression |
| Style recalculations | 1,037 | 872 | 15.9% fewer |
| Style recalculation time | 70.29 ms | 66.17 ms | 5.9% less |
| Initial route JS, gzip | 65.81 kB | 46.16 kB | 29.9% smaller |
| React Doctor warnings | 8 | 4 | 4 motion warnings resolved |

Process-wide task duration varied with machine load and is excluded from the improvement claims. Full methodology and reproduction steps are in `docs/timeline-performance.md`.

## Verification

- `pnpm check`
- `pnpm build`
- React Doctor v0.9.12 before/after
- seven-trial production timeline benchmark before/after
- complete 2011–2026 vertical-to-horizontal timeline traversal at 120 FPS with zero frames over 16.7 ms
