### PR TITLE
fix: keep zoomed timeline nodes in view

### DIFF
--- a/src/components/ConstellationTimeline.tsx
+++ b/src/components/ConstellationTimeline.tsx
@@ -38,6 +38,7 @@ export function ConstellationTimeline({
   const nodeRefs = useRef<Array<HTMLButtonElement | null>>([])
   const [focusIndex, setFocusIndex] = useState(0)
   const [scrollDistance, setScrollDistance] = useState(0)
+  const [stackAbove, setStackAbove] = useState(false)
   const reduceMotion = useReducedMotion()
   const orderedArtifacts = useMemo(
     () => [...artifacts].sort((a, b) => a.date.localeCompare(b.date)),
@@ -61,13 +62,22 @@ export function ConstellationTimeline({
 
     const measure = () => {
       setScrollDistance(Math.max(0, track.scrollWidth - viewport.clientWidth))
+
+      const stickyTop = Number.parseFloat(getComputedStyle(viewport).top) || 0
+      setStackAbove(stickyTop + viewport.clientHeight > window.innerHeight + 1)
     }
     const observer = new ResizeObserver(measure)
     observer.observe(viewport)
     observer.observe(track)
+    window.addEventListener('resize', measure)
+    window.visualViewport?.addEventListener('resize', measure)
     measure()
 
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', measure)
+      window.visualViewport?.removeEventListener('resize', measure)
+    }
   }, [orderedArtifacts.length])
 
   const moveFocus = (index: number) => {
@@ -133,6 +143,7 @@ export function ConstellationTimeline({
       <div
         className="constellation-timeline"
         ref={viewportRef}
+        data-layout={stackAbove ? 'stacked-above' : 'alternating'}
         role="region"
         aria-label="AI interface chronology"
         tabIndex={0}
@@ -164,7 +175,11 @@ export function ConstellationTimeline({
           </m.div>
 
           {orderedArtifacts.map((artifact, index) => {
-            const side = index % 2 === 0 ? 'above' : 'below'
+            const side = stackAbove
+              ? 'above'
+              : index % 2 === 0
+                ? 'above'
+                : 'below'
             const startsYear =
               index === 0 || orderedArtifacts[index - 1]?.year !== artifact.year
 


### PR DESCRIPTION
## Summary

- detect when the sticky timeline is taller than the usable browser viewport
- stack all 47 artifact nodes above the axis at high zoom or short viewport heights
- preserve the alternating 24/23 layout when the complete timeline fits
- react to browser zoom, window resize, and Visual Viewport changes

## Verification

- `pnpm check`
- `pnpm build`
- 1440×900: alternating layout, 24 above and 23 below
- 1440×700 and 1440×500: stacked layout, all 47 above
- 375×812: alternating mobile layout
- 375×500: stacked mobile layout
- full timeline benchmark: 119.98 FPS, 9.2 ms p95, zero over-budget frames, and matching 15,768 px vertical/horizontal travel
